### PR TITLE
feat: add support for +-5 min clock skew

### DIFF
--- a/pkg/pgp/key_test.go
+++ b/pkg/pgp/key_test.go
@@ -5,9 +5,13 @@
 package pgp_test
 
 import (
+	"crypto"
 	"testing"
 	"time"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	pgpcrypto "github.com/ProtonMail/gopenpgp/v2/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -29,4 +33,83 @@ func TestKeyFlow(t *testing.T) {
 	assert.NoError(t, key.Verify(message, signature))
 	assert.Error(t, key.Verify(message[:len(message)-1], signature))
 	assert.Error(t, key.Verify(message, signature[:len(signature)-1]))
+}
+
+func genKey(t *testing.T, lifetimeSecs uint32, now func() time.Time) *pgp.Key {
+	cfg := &packet.Config{
+		Algorithm:              packet.PubKeyAlgoEdDSA,
+		DefaultHash:            crypto.SHA256,
+		DefaultCipher:          packet.CipherAES256,
+		DefaultCompressionAlgo: packet.CompressionZLIB,
+		KeyLifetimeSecs:        lifetimeSecs,
+		SigLifetimeSecs:        lifetimeSecs,
+		Time:                   now,
+	}
+
+	entity, err := openpgp.NewEntity("test", "test", "keytest@example.com", cfg)
+	require.NoError(t, err)
+
+	key, err := pgpcrypto.NewKeyFromEntity(entity)
+	require.NoError(t, err)
+
+	pgpKey, err := pgp.NewKey(key)
+	require.NoError(t, err)
+
+	return pgpKey
+}
+
+func TestKeyExpiration(t *testing.T) {
+	for _, tt := range []struct { //nolint:govet
+		name          string
+		lifetime      time.Duration
+		shift         time.Duration
+		expectedError string
+	}{
+		{
+			name:          "no expiration",
+			expectedError: "key does not contain a valid key lifetime",
+		},
+		{
+			name:          "expiration too long",
+			lifetime:      pgp.MaxAllowedLifetime + 1*time.Hour,
+			expectedError: "key lifetime is too long: 9h0m0s",
+		},
+		{
+			name:          "generated in the future",
+			lifetime:      pgp.MaxAllowedLifetime / 2,
+			shift:         pgp.AllowedClockSkew * 2,
+			expectedError: "key expired",
+		},
+		{
+			name:          "already expired",
+			lifetime:      pgp.MaxAllowedLifetime / 2,
+			shift:         -pgp.AllowedClockSkew*2 - pgp.MaxAllowedLifetime/2,
+			expectedError: "key expired",
+		},
+		{
+			name:     "within clock skew -",
+			lifetime: pgp.MaxAllowedLifetime / 2,
+			shift:    -pgp.AllowedClockSkew / 2,
+		},
+		{
+			name:     "within clock skew +",
+			lifetime: pgp.MaxAllowedLifetime / 2,
+			shift:    pgp.AllowedClockSkew / 2,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			key := genKey(t, uint32(tt.lifetime/time.Second), func() time.Time {
+				return time.Now().Add(tt.shift)
+			})
+
+			err := key.Validate()
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
By default PGP library considers any key which was generated "in the future" as expired without any allowed clock skew. This fixes that, and adds some tests.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>