### PR TITLE
fix: limit clock skew for short-lived keys

### DIFF
--- a/pkg/pgp/key_test.go
+++ b/pkg/pgp/key_test.go
@@ -96,6 +96,10 @@ func TestKeyExpiration(t *testing.T) {
 			lifetime: pgp.MaxAllowedLifetime / 2,
 			shift:    pgp.AllowedClockSkew / 2,
 		},
+		{
+			name:     "short-lived key",
+			lifetime: pgp.AllowedClockSkew / 2,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			key := genKey(t, uint32(tt.lifetime/time.Second), func() time.Time {


### PR DESCRIPTION
If the key expires in 30 secs, limit clock skew otherwise key is considered expired always.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>