### PR TITLE
fix: always print the login URL on key renew flow

### DIFF
--- a/pkg/client/interceptor/key.go
+++ b/pkg/client/interceptor/key.go
@@ -54,6 +54,8 @@ func renewUserKeyViaAuthFlow(ctx context.Context, cc *grpc.ClientConn, options *
 	if browserEnv == "echo" {
 		printLoginDialog()
 	} else {
+		fmt.Fprintf(os.Stderr, "Attempting to open URL: %s\n", loginURL)
+
 		err = browser.OpenURL(loginURL)
 		if err != nil {
 			printLoginDialog()


### PR DESCRIPTION
Instead of printing the login URL only when env var `BROWSER=echo` is set, always print it to stderr. So if the `browser` package fails to open the URL but "thinks" that it didn't fail, we still have the URL printed to the console.