### PR TITLE
fix: get rid of data race in the key sign interceptor

### DIFF
--- a/pkg/pgp/key.go
+++ b/pkg/pgp/key.go
@@ -8,6 +8,7 @@ package pgp
 import (
 	"crypto"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -19,6 +20,7 @@ import (
 type Key struct {
 	key     *pgpcrypto.Key
 	keyring *pgpcrypto.KeyRing
+	mu      sync.Mutex
 }
 
 // GenerateKey generates a new PGP key pair.
@@ -77,6 +79,9 @@ func (p *Key) Verify(data, signature []byte) error {
 
 // Sign signs the given data using the private key.
 func (p *Key) Sign(data []byte) ([]byte, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	message := pgpcrypto.NewPlainMessage(data)
 
 	signature, err := p.keyring.SignDetached(message)


### PR DESCRIPTION
The code underneath is not thread safe and it looks like we need a mutex.