### PR TITLE
fix: account for time truncation to a second resolution

### DIFF
--- a/pkg/pgp/key_test.go
+++ b/pkg/pgp/key_test.go
@@ -170,6 +170,16 @@ func TestKeyValidation(t *testing.T) {
 				pgp.WithValidEmailAsName(false),
 			},
 		},
+		{
+			name:     "should be ok",
+			email:    "keytest@example.com",
+			lifetime: pgp.DefaultMaxAllowedLifetime,
+		},
+		{
+			name:     "should be ok (with time truncation)",
+			email:    "keytest@example.com",
+			lifetime: pgp.DefaultMaxAllowedLifetime + time.Minute - time.Nanosecond,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			key := genKey(t, uint32(tt.lifetime/time.Second), tt.email, func() time.Time {

--- a/pkg/pgp/validate.go
+++ b/pkg/pgp/validate.go
@@ -100,7 +100,10 @@ func (p *Key) validateLifetime(opts *validationOptions) error {
 		return fmt.Errorf("key does not contain a valid key lifetime")
 	}
 
-	expiration := time.Now().Add(opts.maxAllowedLifetime)
+	// We don't care when the key was created, only when it expires relative to the server "now" time.
+	//
+	// Also add one minute to account for rounding errors or time skew.
+	expiration := time.Now().Add(opts.maxAllowedLifetime + time.Minute)
 
 	if !entity.PrimaryKey.KeyExpired(sig, expiration) {
 		return fmt.Errorf("key lifetime is too long: %s", time.Duration(*sig.KeyLifetimeSecs)*time.Second)


### PR DESCRIPTION
ProtonMail go-crypto library introduced a breaking change in `packet.PublicKey.KeyExpired` method. Account for it.