### PR TITLE
fix: return `invalid signature` error when a signature is required

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-06T14:50:11Z by kres 7f1d58a.
+# Generated on 2025-09-22T15:45:31Z by kres fdbc9fc.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -26,13 +26,12 @@ jobs:
       packages: write
       pull-requests: read
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.1
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |
@@ -56,7 +55,7 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -70,21 +69,6 @@ jobs:
       - name: base
         run: |
           make base
-      - name: unit-tests
-        run: |
-          make unit-tests
-      - name: unit-tests-race
-        run: |
-          make unit-tests-race
-      - name: coverage
-        uses: codecov/codecov-action@v5
-        with:
-          files: _out/coverage-unit-tests.txt
-          token: ${{ secrets.CODECOV_TOKEN }}
-        timeout-minutes: 3
-      - name: lint
-        run: |
-          make lint
       - name: release-notes
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -95,3 +79,107 @@ jobs:
         with:
           body_path: _out/RELEASE_NOTES.md
           draft: "true"
+  lint:
+    runs-on:
+      group: generic
+    if: github.event_name == 'pull_request'
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v5
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: lint
+        run: |
+          make lint
+  unit-tests:
+    runs-on:
+      group: generic
+    if: github.event_name == 'pull_request'
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v5
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: unit-tests
+        run: |
+          make unit-tests
+      - name: unit-tests-race
+        run: |
+          make unit-tests-race
+      - name: coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: _out/coverage-unit-tests.txt
+          flags: unit-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
+        timeout-minutes: 3

--- a/.github/workflows/slack-notify-ci-failure.yaml
+++ b/.github/workflows/slack-notify-ci-failure.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-06T14:50:11Z by kres 7f1d58a.
+# Generated on 2025-09-22T15:45:31Z by kres fdbc9fc.
 
 "on":
   workflow_run:
@@ -14,8 +14,7 @@ name: slack-notify-failure
 jobs:
   slack-notify:
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request'
     steps:
       - name: Slack Notify

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-06T14:50:11Z by kres 7f1d58a.
+# Generated on 2025-09-22T15:45:31Z by kres fdbc9fc.
 
 "on":
   workflow_run:
@@ -12,8 +12,7 @@ name: slack-notify
 jobs:
   slack-notify:
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: github.event.workflow_run.conclusion != 'skipped'
     steps:
       - name: Get PR number

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-06T14:50:11Z by kres 7f1d58a.
+# Generated on 2025-09-22T15:45:31Z by kres fdbc9fc.
 
 "on":
   schedule:
@@ -15,7 +15,7 @@ jobs:
       - ubuntu-latest
     steps:
       - name: Close stale issues and PRs
-        uses: actions/stale@v9.1.0
+        uses: actions/stale@v10.0.0
         with:
           close-issue-message: This issue was closed because it has been stalled for 7 days with no activity.
           days-before-issue-close: "5"

--- a/pkg/message/http_test.go
+++ b/pkg/message/http_test.go
@@ -137,3 +137,35 @@ func TestHTTP(t *testing.T) {
 		})
 	}
 }
+
+func TestHTTPMessageSignatures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid signature", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+		require.NoError(t, err)
+
+		m, err := message.NewHTTP(req)
+		require.NoError(t, err)
+
+		_, err = m.Signature()
+		require.ErrorIs(t, err, message.ErrInvalidSignature)
+	})
+
+	t.Run("no signature", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+		require.NoError(t, err)
+
+		m, err := message.NewHTTP(req, message.WithSignatureRequiredCheck(func() (bool, error) {
+			return false, nil
+		}))
+		require.NoError(t, err)
+
+		_, err = m.Signature()
+		require.ErrorIs(t, err, message.ErrNotFound)
+	})
+}

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -2,5 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package message contains gRPC & HTTP related auth functionality.
+// Package message contains gRPC & HTTP-related auth functionality.
 package message

--- a/pkg/message/payload.go
+++ b/pkg/message/payload.go
@@ -16,7 +16,7 @@ var includedHeaders = []string{
 	NodesHeaderKey,
 	SelectorsHeaderKey,
 	FieldSelectorsHeaderKey,
-	RuntimeHeaderHey,
+	RuntimeHeaderKey,
 	ContextHeaderKey,
 	ClusterHeaderKey,
 	NamespaceHeaderKey,


### PR DESCRIPTION
If a message signature is required but is not found when it is attempted to be accessed, fail with `invalid signature` instead of `not found`.

Provide a functional option to customize this behavior.